### PR TITLE
[docs] Change source reference in README to reflect registry source address

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Many examples are included in the [examples](./examples/) folder, but simle usag
 
 ```hcl
 module "org-policy" {
-  source            = "github.com/terraform-google-modules/terraform-google-org-policy?ref=v1.0.0"
+  source            = "terraform-google-modules/org-policy/google"
 
   constraint        = "constraints/serviceuser.services"
   policy_type       = "list"


### PR DESCRIPTION

This PR changes the github source referenced in the README example docs to a standard registry source address to reference the published registry module.
