### PR TITLE
Provide example of restricting IAM users to a specific domain (119775895)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ To control module's behavior, change variables' values regarding the following:
   - `enforce`: if "true" policy will deny all, if "false" policy will allow all (default `true`)
   - `allow`: list of values to include in the policy with ALLOW behavior
   - `deny`: list of values to include in the policy with DENY behavior
+- List policies with allow or deny values require the length to be set ( a workaround for [this terraform issue](https://github.com/hashicorp/terraform/issues/10857))
+  - `allow_list_length`
+  - `deny_list_length`
 
 [^]: (autogen_docs_start)
 
@@ -44,8 +47,10 @@ To control module's behavior, change variables' values regarding the following:
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allow | (Only for list constraints) List of values which should be allowed | list | `<list>` | no |
+| allow_list_length | (Only for allow list constraints) Count of the number of values in the allow list | string | "0" | no |
 | constraint | The constraint to be applied | string | - | yes |
 | deny | (Only for list constraints) List of values which should be denied | list | `<list>` | no |
+| deny_list_length | (Only for allow list constraints) Count of the number of values in the deny list | string | "0" | no |
 | enforce | If boolean constraint, whether the policy is enforced at the root; if list constraint, whether to deny all (true) or allow all | string | `` | no |
 | exclude_folders | List of folders to exclude from the policy | list | `<list>` | no |
 | exclude_projects | List of projects to exclude from the policy | list | `<list>` | no |

--- a/examples/list_folder_deny/main.tf
+++ b/examples/list_folder_deny/main.tf
@@ -31,4 +31,5 @@ module "org-policy" {
   constraint = "serviceuser.services"
   policy_type = "list"
   deny        = ["deploymentmanager.googleapis.com"]
+  deny_list_length = "1"
 }

--- a/examples/list_org_exclude/main.tf
+++ b/examples/list_org_exclude/main.tf
@@ -31,5 +31,6 @@ module "org-policy" {
   constraint       = "compute.trustedImageProjects"
   policy_type      = "list"
   allow            = ["projects/${var.image_project_id}"]
+  allow_list_length = "1"
   exclude_projects = ["${var.image_project_id}"]
 }

--- a/examples/list_restrict_domain/README.md
+++ b/examples/list_restrict_domain/README.md
@@ -1,0 +1,18 @@
+# Restrict Domain Constraint
+
+This example shows how to set a list constraint on an org level.
+
+Specifically, it sets a restricted domain policy so only users from a specified domains can be added to IAM policies.
+
+[^]: (autogen_docs_start)
+
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
+| credentials_file_path | Service account json auth path | string | - | yes |
+| organization_id | The organization id the policy is applied to | string | - | yes |
+| domain_customer_ids | The list of customer ids to restrict access to (see [details](https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains#retrieving_customer_id)] | list | - | yes | 
+
+[^]: (autogen_docs_end)

--- a/examples/list_restrict_domain/README.md
+++ b/examples/list_restrict_domain/README.md
@@ -13,6 +13,6 @@ Specifically, it sets a restricted domain policy so only users from a specified 
 |------|-------------|:----:|:-----:|:-----:|
 | credentials_file_path | Service account json auth path | string | - | yes |
 | organization_id | The organization id the policy is applied to | string | - | yes |
-| domain_customer_ids | The list of customer ids to restrict access to (see [details](https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains#retrieving_customer_id)] | list | - | yes | 
+| domain_to_allow | The domain to restrict access to | string | - | yes | 
 
 [^]: (autogen_docs_end)

--- a/examples/list_restrict_domain/input_vars.tfvars
+++ b/examples/list_restrict_domain/input_vars.tfvars
@@ -1,0 +1,3 @@
+credentials_file_path = "/Users/rishimalik/code/project-factory-service-account-credentials.json"
+organization_id = 826592752744
+domain_to_allow = "phoogle.net"

--- a/examples/list_restrict_domain/main.tf
+++ b/examples/list_restrict_domain/main.tf
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/******************************************
+  Provider configuration
+ *****************************************/
+provider "google" {
+  credentials = "${file(var.credentials_file_path)}"
+}
+
+/******************************************
+  Look up customer id if necessary
+ *****************************************/
+data "google_organization" "org" {
+  domain = "${var.domain_to_allow}"
+}
+
+/******************************************
+  Specify specific resource for policy
+ *****************************************/
+resource "google_organization_policy" "org_policy_list_allow_values" {
+  org_id     = "${var.organization_id}"
+  constraint = "constraints/iam.allowedPolicyMemberDomains"
+
+  list_policy {
+    allow {
+      values = ["${data.google_organization.org.directory_customer_id}"]
+    }
+  }
+}

--- a/examples/list_restrict_domain/main.tf
+++ b/examples/list_restrict_domain/main.tf
@@ -28,16 +28,13 @@ data "google_organization" "org" {
   domain = "${var.domain_to_allow}"
 }
 
-/******************************************
-  Specify specific resource for policy
- *****************************************/
-resource "google_organization_policy" "org_policy_list_allow_values" {
-  org_id     = "${var.organization_id}"
-  constraint = "constraints/iam.allowedPolicyMemberDomains"
+module "org-policy" {
+  source = "../../"
 
-  list_policy {
-    allow {
-      values = ["${data.google_organization.org.directory_customer_id}"]
-    }
-  }
+  organization_id  = "${var.organization_id}"
+  constraint       = "constraints/iam.allowedPolicyMemberDomains"
+  policy_type      = "list"
+  allow            = ["${data.google_organization.org.directory_customer_id}"]
+  allow_list_length = "1"
 }
+

--- a/examples/list_restrict_domain/variables.tf
+++ b/examples/list_restrict_domain/variables.tf
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2018 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "credentials_file_path" {
+  description = "Service account json auth path"
+}
+
+variable "organization_id" {
+  description = "The organization id the policy is applied to"
+}
+
+variable "domain_to_allow" {
+  description = "The domain to allow users from"
+}

--- a/list_constraints.tf
+++ b/list_constraints.tf
@@ -18,7 +18,7 @@
   Organization policy, allow all (list constraint)
  *****************************************/
 resource "google_organization_policy" "org_policy_list_allow_all" {
-  count = "${local.organization && local.list_policy && local.enforce == "false" && local.deny_list_length == 0 ? 1 : 0}"
+  count = "${local.organization && local.list_policy && local.enforce == "false" && var.deny_list_length == 0 ? 1 : 0}"
 
   org_id     = "${var.organization_id}"
   constraint = "${var.constraint}"
@@ -34,7 +34,7 @@ resource "google_organization_policy" "org_policy_list_allow_all" {
   Folder policy, allow all (list constraint)
  *****************************************/
 resource "google_folder_organization_policy" "folder_policy_list_allow_all" {
-  count = "${local.folder && local.list_policy && local.enforce == "false" && local.deny_list_length == 0 ? 1 : 0}"
+  count = "${local.folder && local.list_policy && local.enforce == "false" && var.deny_list_length == 0 ? 1 : 0}"
 
   folder     = "${var.folder_id}"
   constraint = "${var.constraint}"
@@ -50,7 +50,7 @@ resource "google_folder_organization_policy" "folder_policy_list_allow_all" {
   Project policy, allow all (list constraint)
  *****************************************/
 resource "google_project_organization_policy" "project_policy_list_allow_all" {
-  count = "${local.project && local.list_policy && local.enforce == "false" && local.deny_list_length == 0 ? 1 : 0}"
+  count = "${local.project && local.list_policy && local.enforce == "false" && var.deny_list_length == 0 ? 1 : 0}"
 
   project    = "${var.project_id}"
   constraint = "${var.constraint}"
@@ -66,7 +66,7 @@ resource "google_project_organization_policy" "project_policy_list_allow_all" {
   Organization policy, deny all (list constraint)
  *****************************************/
 resource "google_organization_policy" "org_policy_list_deny_all" {
-  count = "${local.organization && local.list_policy && local.enforce == "true" && local.deny_list_length == 0 ? 1 : 0}"
+  count = "${local.organization && local.list_policy && local.enforce == "true" && var.deny_list_length == 0 ? 1 : 0}"
 
   org_id     = "${var.organization_id}"
   constraint = "${var.constraint}"
@@ -82,7 +82,7 @@ resource "google_organization_policy" "org_policy_list_deny_all" {
   Folder policy, deny all (list constraint)
  *****************************************/
 resource "google_folder_organization_policy" "folder_policy_list_deny_all" {
-  count = "${local.folder && local.list_policy && local.enforce == "true" && local.deny_list_length == 0 ? 1 : 0}"
+  count = "${local.folder && local.list_policy && local.enforce == "true" && var.deny_list_length == 0 ? 1 : 0}"
 
   folder     = "${var.folder_id}"
   constraint = "${var.constraint}"
@@ -98,7 +98,7 @@ resource "google_folder_organization_policy" "folder_policy_list_deny_all" {
   Project policy, deny all (list constraint)
  *****************************************/
 resource "google_project_organization_policy" "project_policy_list_deny_all" {
-  count = "${local.project && local.list_policy && local.enforce == "true" && local.deny_list_length == 0 ? 1 : 0}"
+  count = "${local.project && local.list_policy && local.enforce == "true" && var.deny_list_length == 0 ? 1 : 0}"
 
   project    = "${var.project_id}"
   constraint = "${var.constraint}"
@@ -114,7 +114,7 @@ resource "google_project_organization_policy" "project_policy_list_deny_all" {
   Organization policy, deny values (list constraint)
  *****************************************/
 resource "google_organization_policy" "org_policy_list_deny_values" {
-  count = "${local.organization && local.list_policy && local.deny_list_length > 0 ? 1 : 0}"
+  count = "${local.organization && local.list_policy && var.deny_list_length > 0 ? 1 : 0}"
 
   org_id     = "${var.organization_id}"
   constraint = "${var.constraint}"
@@ -130,7 +130,7 @@ resource "google_organization_policy" "org_policy_list_deny_values" {
   Folder policy, deny values (list constraint)
  *****************************************/
 resource "google_folder_organization_policy" "folder_policy_list_deny_values" {
-  count = "${local.folder && local.list_policy && local.deny_list_length > 0 ? 1 : 0}"
+  count = "${local.folder && local.list_policy && var.deny_list_length > 0 ? 1 : 0}"
 
   folder     = "${var.folder_id}"
   constraint = "${var.constraint}"
@@ -146,7 +146,7 @@ resource "google_folder_organization_policy" "folder_policy_list_deny_values" {
   Project policy, deny values (list constraint)
  *****************************************/
 resource "google_project_organization_policy" "project_policy_list_deny_values" {
-  count = "${local.project && local.list_policy && local.deny_list_length > 0 ? 1 : 0}"
+  count = "${local.project && local.list_policy && var.deny_list_length > 0 ? 1 : 0}"
 
   project    = "${var.project_id}"
   constraint = "${var.constraint}"
@@ -162,7 +162,7 @@ resource "google_project_organization_policy" "project_policy_list_deny_values" 
   Organization policy, allow values (list constraint)
  *****************************************/
 resource "google_organization_policy" "org_policy_list_allow_values" {
-  count = "${local.organization && local.list_policy && local.allow_list_length > 0 ? 1 : 0}"
+  count = "${local.organization && local.list_policy && var.allow_list_length > 0 ? 1 : 0}"
 
   org_id     = "${var.organization_id}"
   constraint = "${var.constraint}"
@@ -178,7 +178,7 @@ resource "google_organization_policy" "org_policy_list_allow_values" {
   Folder policy, allow values (list constraint)
  *****************************************/
 resource "google_folder_organization_policy" "folder_policy_list_allow_values" {
-  count = "${local.folder && local.list_policy && local.allow_list_length > 0 ? 1 : 0}"
+  count = "${local.folder && local.list_policy && var.allow_list_length > 0 ? 1 : 0}"
 
   folder     = "${var.folder_id}"
   constraint = "${var.constraint}"
@@ -194,7 +194,7 @@ resource "google_folder_organization_policy" "folder_policy_list_allow_values" {
   Project policy, allow values (list constraint)
  *****************************************/
 resource "google_project_organization_policy" "project_policy_list_allow_values" {
-  count = "${local.project && local.list_policy && local.allow_list_length > 0 ? 1 : 0}"
+  count = "${local.project && local.list_policy && var.allow_list_length > 0 ? 1 : 0}"
 
   project    = "${var.project_id}"
   constraint = "${var.constraint}"

--- a/main.tf
+++ b/main.tf
@@ -23,13 +23,11 @@ locals {
   project                      = "${var.project_id != ""}"
   boolean_policy               = "${var.policy_type == "boolean" }"
   list_policy                  = "${var.policy_type == "list" && !local.invalid_config}"
-  deny_list_length             = "${length(compact(var.deny))}"
-  allow_list_length            = "${length(compact(var.allow))}"
-  enforce                      = "${(local.allow_list_length > 0 || local.deny_list_length > 0) ? "" : var.enforce}"
+  enforce                      = "${(var.allow_list_length > 0 || var.deny_list_length > 0) ? "" : var.enforce}"
   exclude_folders_list_length  = "${length(compact(var.exclude_folders))}"
   exclude_projects_list_length = "${length(compact(var.exclude_projects))}"
-  invalid_config_case_1        = "${local.deny_list_length > 0 && local.allow_list_length > 0}"
-  invalid_config_case_2        = "${(local.allow_list_length + local.deny_list_length) > 0 && (var.enforce == "true" || local.enforce == "false")}"
+  invalid_config_case_1        = "${var.deny_list_length > 0 && var.allow_list_length > 0}"
+  invalid_config_case_2        = "${(var.allow_list_length + var.deny_list_length) > 0 && (var.enforce == "true" || local.enforce == "false")}"
   invalid_config               = "${var.policy_type == "list" && (local.invalid_config_case_1 || local.invalid_config_case_2)}"
 }
 

--- a/test/integration/list_constraints/integration.bats
+++ b/test/integration/list_constraints/integration.bats
@@ -22,7 +22,7 @@ load helpers
 
   run terraform plan
   [ "$status" -eq 0 ]
-  [[ "$output" =~ 6\ to\ add ]]
+  [[ "$output" =~ 7\ to\ add ]]
   [[ "$output" =~ 0\ to\ change ]]
   [[ "$output" =~ 0\ to\ destroy ]]
 }
@@ -31,7 +31,7 @@ load helpers
 
   run terraform apply -auto-approve -parallelism=1
   [ "$status" -eq 0 ]
-  [[ "$output" =~ 6\ added ]]
+  [[ "$output" =~ 7\ added ]]
   [[ "$output" =~ 0\ changed ]]
   [[ "$output" =~ 0\ destroyed ]]
 }
@@ -56,6 +56,16 @@ load helpers
   run echo "$RESULT"
   [ "$status" -eq 0 ]
   [[ "$output" = "true" ]]
+}
+
+@test "Test constraints on organization $ORGANIZATION_ID (restrict values) constraining $ORG_RESTRICT_DOMAIN_CONSTRAINT to $ORG_RESTRICT_DOMAIN_CONSTRAINT_VALUE_1" {
+
+  POLICY=$(gcloud beta resource-manager org-policies list --organization "$ORGANIZATION_ID" --format="json")
+  RESULT=$(check_list_policy_values "$ORG_RESTRICT_DOMAIN_CONSTRAINT" "$POLICY" "allow" "$ORG_RESTRICT_DOMAIN_CONSTRAINT_VALUE_1")
+  run echo "$RESULT"
+  [ "$status" -eq 0 ]
+  [[ "$output" = "true" ]]
+
 }
 
 @test "Test constraints on organization $ORGANIZATION_ID (deny values) and project $PROJECT_EXCLUDE and folder $FOLDER_EXCLUDE (exclusions)" {
@@ -96,5 +106,5 @@ load helpers
 
   run terraform destroy -force
   [ "$status" -eq 0 ]
-  [[ "$output" =~ 6\ destroyed ]]
+  [[ "$output" =~ 7\ destroyed ]]
 }

--- a/test/integration/list_constraints/integration.bats
+++ b/test/integration/list_constraints/integration.bats
@@ -30,6 +30,7 @@ load helpers
 @test "Terraform apply" {
 
   run terraform apply -auto-approve -parallelism=1
+
   [ "$status" -eq 0 ]
   [[ "$output" =~ 7\ added ]]
   [[ "$output" =~ 0\ changed ]]

--- a/test/integration/list_constraints/launch.sh
+++ b/test/integration/list_constraints/launch.sh
@@ -90,6 +90,15 @@ provider "google" {
   credentials              = "\${file(local.credentials_file_path)}"
 }
 
+module "org-policy-restrict-domain" {
+  source = "../../../"
+
+  organization_id  = "$ORGANIZATION_ID"
+  constraint       = "$ORG_RESTRICT_DOMAIN_CONSTRAINT"
+  policy_type      = "list"
+  allow            = ["$ORG_RESTRICT_DOMAIN_CONSTRAINT_VALUE_1"]
+}
+
 module "org-policy-list-project" {
   source = "../../../"
 

--- a/test/integration/list_constraints/launch.sh
+++ b/test/integration/list_constraints/launch.sh
@@ -101,6 +101,7 @@ module "org-policy-restrict-domain" {
   constraint       = "$ORG_RESTRICT_DOMAIN_CONSTRAINT"
   policy_type      = "list"
   allow            = ["$ORG_RESTRICT_DOMAIN_CONSTRAINT_VALUE_1"]
+  allow_list_length = "1"
 }
 
 module "org-policy-list-project" {
@@ -132,6 +133,7 @@ module "org-policy-list-org" {
   exclude_projects = ["$PROJECT_EXCLUDE"]
 
   deny             = ["$ORG_CONSTRAINT_VALUE_1", "$ORG_CONSTRAINT_VALUE_2"]
+  deny_list_length = "2"
 
 }
 
@@ -143,7 +145,7 @@ module "org-policy-list-folder-2" {
   policy_type      = "list"
 
   allow             = ["$FOLDER_2_CONSTRAINT_VALUE_1"]
-
+  allow_list_length = "1"
 }
 
 EOF

--- a/test/integration/list_constraints/launch.sh
+++ b/test/integration/list_constraints/launch.sh
@@ -57,6 +57,10 @@ export ORG_CONSTRAINT="constraints/serviceuser.services"
 export ORG_CONSTRAINT_VALUE_1="doubleclicksearch.googleapis.com"
 export ORG_CONSTRAINT_VALUE_2="resourceviews.googleapis.com"
 
+# Applied to: org
+export ORG_RESTRICT_DOMAIN_CONSTRAINT="constraints/iam.allowedPolicyMemberDomains"
+export ORG_RESTRICT_DOMAIN_CONSTRAINT_VALUE_1="C00u46n4k"
+
 # Applied to: folder 2
 export FOLDER_2_CONSTRAINT="constraints/compute.trustedImageProjects"
 export FOLDER_2_CONSTRAINT_VALUE_1="projects/base-project-196723"

--- a/variables.tf
+++ b/variables.tf
@@ -67,3 +67,13 @@ variable "policy_type" {
   type        = "string"
   default     = "list"
 }
+
+variable "allow_list_length" {
+  description = "The number of elements in the allow list"
+  default = 0
+}
+
+variable "deny_list_length" {
+  description = "The number of elements in the allow list"
+  default = 0
+}


### PR DESCRIPTION
Note that most of this PR is putting in a workaround for: https://github.com/hashicorp/terraform/issues/10857

When the value being passed in is computed, the length checks that existed before fail. This should be able to be implemented more cleanly in Terraform v0.12, when conditions with short-circuit evaluation are implemented.