### PR TITLE
Fixes #8:

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,23 +41,22 @@ To control module's behavior, change variables' values regarding the following:
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | allow | (Only for list constraints) List of values which should be allowed | list | `<list>` | no |
-| allow_list_length | (Only for allow list constraints) Count of the number of values in the allow list | string | "0" | no |
-| constraint | The constraint to be applied | string | - | yes |
+| allow\_list\_length | The number of elements in the allow list | string | `"0"` | no |
+| constraint | The constraint to be applied | string | n/a | yes |
 | deny | (Only for list constraints) List of values which should be denied | list | `<list>` | no |
-| deny_list_length | (Only for allow list constraints) Count of the number of values in the deny list | string | "0" | no |
-| enforce | If boolean constraint, whether the policy is enforced at the root; if list constraint, whether to deny all (true) or allow all | string | `` | no |
-| exclude_folders | List of folders to exclude from the policy | list | `<list>` | no |
-| exclude_projects | List of projects to exclude from the policy | list | `<list>` | no |
-| folder_id | The folder id for putting the policy | string | `` | no |
-| organization_id | The organization id for putting the policy | string | `` | no |
-| policy_type | The constraint type to work with (either 'boolean' or 'list') | string | `list` | no |
-| project_id | The project id for putting the policy | string | `` | no |
+| deny\_list\_length | The number of elements in the allow list | string | `"0"` | no |
+| enforce | If boolean constraint, whether the policy is enforced at the root; if list constraint, whether to deny all (true) or allow all | string | `""` | no |
+| exclude\_folders | List of folders to exclude from the policy | list | `<list>` | no |
+| exclude\_projects | List of projects to exclude from the policy | list | `<list>` | no |
+| folder\_id | The folder id for putting the policy | string | `""` | no |
+| organization\_id | The organization id for putting the policy | string | `""` | no |
+| policy\_type | The constraint type to work with (either 'boolean' or 'list') | string | `"list"` | no |
+| project\_id | The project id for putting the policy | string | `""` | no |
 
 [^]: (autogen_docs_end)
 

--- a/examples/boolean_org_exclude/README.md
+++ b/examples/boolean_org_exclude/README.md
@@ -19,13 +19,12 @@ module "folder-disable-serial-port-access-enforce-with-excludes" {
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_file_path | Service account json auth path | string | - | yes |
-| excluded_folder_id | ID of a folder to exclude from the policy | string | - | yes |
-| organization_id | The organization id for putting the policy | string | - | yes |
+| credentials\_file\_path | Service account json auth path | string | n/a | yes |
+| excluded\_folder\_id | ID of a folder to exclude from the policy | string | n/a | yes |
+| organization\_id | The organization id for putting the policy | string | n/a | yes |
 
 [^]: (autogen_docs_end)

--- a/examples/boolean_project_allow/README.md
+++ b/examples/boolean_project_allow/README.md
@@ -5,12 +5,11 @@ It disables enforcement of the `compute.disableSerialPortAccess` constraint on t
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_file_path | Service account json auth path | string | - | yes |
-| project_id | The project ID to apply the policy to | string | - | yes |
+| credentials\_file\_path | Service account json auth path | string | n/a | yes |
+| project\_id | The project ID to apply the policy to | string | n/a | yes |
 
 [^]: (autogen_docs_end)

--- a/examples/list_folder_deny/README.md
+++ b/examples/list_folder_deny/README.md
@@ -3,12 +3,11 @@ This example shows how a list constraint can be applied to disallow certain serv
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_file_path | Service account json auth path | string | - | yes |
-| folder_id | The folder id for putting the policy | string | - | yes |
+| credentials\_file\_path | Service account json auth path | string | n/a | yes |
+| folder\_id | The folder id for putting the policy | string | n/a | yes |
 
 [^]: (autogen_docs_end)

--- a/examples/list_org_exclude/README.md
+++ b/examples/list_org_exclude/README.md
@@ -6,13 +6,12 @@ Specifically, it sets a trusted image policy so only images from a trusted image
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_file_path | Service account json auth path | string | - | yes |
-| image_project_id | The ID of a project to trust images from | string | - | yes |
-| organization_id | The organization id for putting the policy | string | - | yes |
+| credentials\_file\_path | Service account json auth path | string | n/a | yes |
+| image\_project\_id | The ID of a project to trust images from | string | n/a | yes |
+| organization\_id | The organization id for putting the policy | string | n/a | yes |
 
 [^]: (autogen_docs_end)

--- a/examples/list_restrict_domain/README.md
+++ b/examples/list_restrict_domain/README.md
@@ -6,13 +6,12 @@ Specifically, it sets a restricted domain policy so only users from a specified 
 
 [^]: (autogen_docs_start)
 
-
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
-| credentials_file_path | Service account json auth path | string | - | yes |
-| organization_id | The organization id the policy is applied to | string | - | yes |
-| domain_to_allow | The domain to restrict access to | string | - | yes | 
+| credentials\_file\_path | Service account json auth path | string | n/a | yes |
+| domain\_to\_allow | The domain to allow users from | string | n/a | yes |
+| organization\_id | The organization id the policy is applied to | string | n/a | yes |
 
 [^]: (autogen_docs_end)

--- a/helpers/combine_docfiles.py
+++ b/helpers/combine_docfiles.py
@@ -14,31 +14,36 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-''' Combine file from:
-  * script argument 1
-  with content of file from:
-  * script argument 2
-  using the beginning of line separators
-  hardcoded using regexes in this file:
+"""
+Combine files as described below.
 
-  We exclude any text using the separate
-  regex specified here
-'''
+* script argument 1
+with content of file from:
+* script argument 2
+using the beginning of line separators
+hardcoded using regexes in this file:
+
+We exclude any text using the separate
+regex specified here
+"""
 
 import re
 import sys
 
-insert_separator_regex = '(.*?\[\^\]\:\ \(autogen_docs_start\))(.*?)(\n\[\^\]\:\ \(autogen_docs_end\).*?$)'
-exclude_separator_regex = '(.*?)Copyright 20\d\d Google LLC.*?limitations under the License.(.*?)$'
+insert_separator_regex = \
+    r'(.*?\[\^\]\:\ \(autogen_docs_start\))(.*?)(\n\[\^\]\:\ \(autogen_docs_end\).*?$)'  # noqa: E501
+exclude_separator_regex = \
+    r'(.*?)Copyright 20\d\d Google LLC.*?limitations under the License.(.*?)$'
 
 if len(sys.argv) != 3:
-  sys.exit(1)
+    sys.exit(1)
 
 input = open(sys.argv[1], "r").read()
 replace_content = open(sys.argv[2], "r").read()
 
 # Exclude the specified content from the replacement content
-groups = re.match(exclude_separator_regex, replace_content, re.DOTALL).groups(0)
+groups = re.match(exclude_separator_regex,
+                  replace_content, re.DOTALL).groups(0)
 replace_content = groups[0] + groups[1]
 
 # Find where to put the replacement content, overwrite the input file

--- a/test/integration/boolean_constraints/launch.sh
+++ b/test/integration/boolean_constraints/launch.sh
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 #################################################################
 #   PLEASE FILL THE VARIABLES WITH VALID VALUES FOR TESTING     #
 #   DO NOT REMOVE/ADD ANY OF THE VARIABLES                      #

--- a/test/integration/list_constraints/launch.sh
+++ b/test/integration/list_constraints/launch.sh
@@ -1,4 +1,4 @@
-#!bin/bash
+#!/bin/bash
 # Copyright 2018 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,9 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
-#!/bin/bash
 
 #################################################################
 #   PLEASE FILL THE VARIABLES WITH VALID VALUES FOR TESTING     #

--- a/test/make.sh
+++ b/test/make.sh
@@ -88,9 +88,9 @@ function check_trailing_whitespace() {
 function generate_docs() {
   echo "Generating markdown docs with terraform-docs"
   TMPFILE=$(mktemp)
-  for j in `for i in $(find . -type f | grep \.tf$) ; do dirname $i ; done | sort -u` ; do
-    terraform-docs markdown $j > $TMPFILE
-    python helpers/combine_docfiles.py $j/README.md $TMPFILE
+  for j in $(for i in $(find . -type f | grep \.tf$) ; do dirname "${i}" ; done | sort -u) ; do
+    terraform-docs markdown "${j}" > "${TMPFILE}"
+    python helpers/combine_docfiles.py "${j}"/README.md "${TMPFILE}"
   done
-  rm -f $TMPFILE
+  rm -f "${TMPFILE}"
 }

--- a/test/verify_boilerplate.py
+++ b/test/verify_boilerplate.py
@@ -53,7 +53,7 @@ def get_args():
     return parser.parse_args()
 
 
-def get_refs(ARGS):
+def get_refs(args):
     """Converts the directory of boilerplate files into a map keyed by file
     extension.
 
@@ -69,7 +69,7 @@ def get_refs(ARGS):
 
     # Find and iterate over the absolute path for each boilerplate template
     for path in glob.glob(os.path.join(
-            ARGS.boilerplate_dir,
+            args.boilerplate_dir,
             "boilerplate.*.txt")):
         extension = os.path.basename(path).split(".")[1]
         ref_file = open(path, 'r')
@@ -177,11 +177,11 @@ def normalize_files(files):
         newfiles.append(pathname)
     for idx, pathname in enumerate(newfiles):
         if not os.path.isabs(pathname):
-            newfiles[idx] = os.path.join(ARGS.rootdir, pathname)
+            newfiles[idx] = os.path.join(args.rootdir, pathname)
     return newfiles
 
 
-def get_files(extensions, ARGS):
+def get_files(extensions, args):
     """Generates a list of paths whose boilerplate should be verified.
 
     If a list of file names has been provided on the command line, it will be
@@ -200,10 +200,10 @@ def get_files(extensions, ARGS):
         A list of absolute file paths
     """
     files = []
-    if ARGS.filenames:
-        files = ARGS.filenames
+    if args.filenames:
+        files = args.filenames
     else:
-        for root, dirs, walkfiles in os.walk(ARGS.rootdir):
+        for root, dirs, walkfiles in os.walk(args.rootdir):
             # don't visit certain dirs. This is just a performance improvement
             # as we would prune these later in normalize_files(). But doing it
             # cuts down the amount of filesystem walking we do and cuts down
@@ -275,5 +275,5 @@ def main(args):
 
 
 if __name__ == "__main__":
-    ARGS = get_args()
-    main(ARGS)
+    args = get_args()
+    main(args)


### PR DESCRIPTION
Fixes #8

- Shell '*.sh':
  - shellcheck: SC2239, SC2006, SC2086

Python:
- helpers/combine_docfiles.py:
  - pydocstyle: D205, D208, D210, D300, D400
  - flake8: W605, E501
- test/verify_boilerplate.py
  - flake8: N803

Makrdown:
- Regenerated docs, fixed trailing whitespace