### PR TITLE
Make exclude_folders and exclude_projects use sets and use for_each to avoid unnecessary resource updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,8 @@ To control module's behavior, change variables' values regarding the following:
 | deny | (Only for list constraints) List of values which should be denied | list(string) | `<list>` | no |
 | deny\_list\_length | The number of elements in the deny list | number | `"0"` | no |
 | enforce | If boolean constraint, whether the policy is enforced at the root; if list constraint, whether to deny all (true) or allow all | bool | `"null"` | no |
-| exclude\_folders | List of folders to exclude from the policy | list(string) | `<list>` | no |
-| exclude\_projects | List of projects to exclude from the policy | list(string) | `<list>` | no |
+| exclude\_folders | Set of folders to exclude from the policy | set(string) | `<list>` | no |
+| exclude\_projects | Set of projects to exclude from the policy | set(string) | `<list>` | no |
 | folder\_id | The folder id for putting the policy | string | `"null"` | no |
 | organization\_id | The organization id for putting the policy | string | `"null"` | no |
 | policy\_for | Resource hierarchy node to apply the policy to: can be one of `organization`, `folder`, or `project`. | string | n/a | yes |

--- a/boolean_constraints.tf
+++ b/boolean_constraints.tf
@@ -60,9 +60,9 @@ resource "google_project_organization_policy" "project_policy_boolean" {
   Exclude folders from policy (boolean constraint)
  *****************************************/
 resource "google_folder_organization_policy" "policy_boolean_exclude_folders" {
-  count = local.boolean_policy && ! local.project ? local.exclude_folders_list_length : 0
+  for_each = (local.boolean_policy && ! local.project) ? var.exclude_folders : []
 
-  folder     = var.exclude_folders[count.index]
+  folder     = each.value
   constraint = var.constraint
 
   boolean_policy {
@@ -74,9 +74,9 @@ resource "google_folder_organization_policy" "policy_boolean_exclude_folders" {
   Exclude projects from policy (boolean constraint)
  *****************************************/
 resource "google_project_organization_policy" "policy_boolean_exclude_projects" {
-  count = local.boolean_policy && ! local.project ? local.exclude_projects_list_length : 0
+  for_each = (local.boolean_policy && ! local.project) ? var.exclude_projects : []
 
-  project    = var.exclude_projects[count.index]
+  project    = each.value
   constraint = var.constraint
 
   boolean_policy {

--- a/list_constraints.tf
+++ b/list_constraints.tf
@@ -210,9 +210,9 @@ resource "google_project_organization_policy" "project_policy_list_allow_values"
   Exclude folders from policy (list constraint)
  *****************************************/
 resource "google_folder_organization_policy" "folder_policy_list_exclude_folders" {
-  count = local.list_policy && ! local.project ? local.exclude_folders_list_length : 0
+  for_each = (local.list_policy && ! local.project) ? var.exclude_folders : []
 
-  folder     = var.exclude_folders[count.index]
+  folder     = each.value
   constraint = var.constraint
 
   restore_policy {
@@ -224,13 +224,12 @@ resource "google_folder_organization_policy" "folder_policy_list_exclude_folders
   Exclude projects from policy (list constraint)
  *****************************************/
 resource "google_project_organization_policy" "project_policy_list_exclude_projects" {
-  count = local.list_policy && ! local.project ? local.exclude_projects_list_length : 0
+  for_each = (local.list_policy && ! local.project) ? var.exclude_projects : []
 
-  project    = var.exclude_projects[count.index]
+  project    = each.value
   constraint = var.constraint
 
   restore_policy {
     default = true
   }
 }
-

--- a/main.tf
+++ b/main.tf
@@ -25,10 +25,8 @@ locals {
   list_policy    = var.policy_type == "list" && ! local.invalid_config
 
   // If allow/deny list empty and enforce is not set, enforce is set to true
-  enforce                      = var.allow_list_length > 0 || var.deny_list_length > 0 ? null : var.enforce != false
-  exclude_folders_list_length  = length(compact(var.exclude_folders))
-  exclude_projects_list_length = length(compact(var.exclude_projects))
-  invalid_config_case_1        = var.deny_list_length > 0 && var.allow_list_length > 0
+  enforce               = var.allow_list_length > 0 || var.deny_list_length > 0 ? null : var.enforce != false
+  invalid_config_case_1 = var.deny_list_length > 0 && var.allow_list_length > 0
 
   // We use var.enforce here because allow/deny lists can not be used together with enforce flag
   invalid_config_case_2 = var.allow_list_length + var.deny_list_length > 0 && var.enforce != null

--- a/variables.tf
+++ b/variables.tf
@@ -57,13 +57,13 @@ variable "deny" {
 variable "exclude_folders" {
   description = "Set of folders to exclude from the policy"
   type        = set(string)
-  default     = [""]
+  default     = []
 }
 
 variable "exclude_projects" {
   description = "Set of projects to exclude from the policy"
   type        = set(string)
-  default     = [""]
+  default     = []
 }
 
 variable "constraint" {

--- a/variables.tf
+++ b/variables.tf
@@ -55,14 +55,14 @@ variable "deny" {
 }
 
 variable "exclude_folders" {
-  description = "List of folders to exclude from the policy"
-  type        = list(string)
+  description = "Set of folders to exclude from the policy"
+  type        = set(string)
   default     = [""]
 }
 
 variable "exclude_projects" {
-  description = "List of projects to exclude from the policy"
-  type        = list(string)
+  description = "Set of projects to exclude from the policy"
+  type        = set(string)
   default     = [""]
 }
 


### PR DESCRIPTION
Currently, when adding new excluded folders or projects in to the middle of the list, Terraform shows unnecessary changes due to index shifts. With this change, this no longer happens. This makes it possible to order the exclusions alphabetically without getting unnecessary changes in the plan.