### PR TITLE
Set organization_id parameter as mandatory because of "google_organization_policy" terraform resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ To control module's behavior, change variables' values regarding the following:
 | exclude\_folders | Set of folders to exclude from the policy | `set(string)` | `[]` | no |
 | exclude\_projects | Set of projects to exclude from the policy | `set(string)` | `[]` | no |
 | folder\_id | The folder id for putting the policy | `string` | `null` | no |
-| organization\_id | The organization id for putting the policy | `string` | `null` | no |
+| organization\_id | The organization id for putting the policy | `string` | n/a | yes |
 | policy\_for | Resource hierarchy node to apply the policy to: can be one of `organization`, `folder`, or `project`. | `string` | n/a | yes |
 | policy\_type | The constraint type to work with (either 'boolean' or 'list') | `string` | `"list"` | no |
 | project\_id | The project id for putting the policy | `string` | `null` | no |

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,6 @@ variable "policy_for" {
 variable "organization_id" {
   description = "The organization id for putting the policy"
   type        = string
-  default     = null
 }
 
 variable "folder_id" {


### PR DESCRIPTION
Terraform application return error when org_id is "null"

The organization id is currently mandatory due to required status org_id parameter in the resource google_organization_policy of terraform module.

![terraform_org_policy_error](https://user-images.githubusercontent.com/15121396/138324142-f9d1cd0a-8255-41e7-bb76-2940876c674f.PNG)

