### PR TITLE
fix: specify rules variable type in org_policy_v2

### DIFF
--- a/modules/org_policy_v2/README.md
+++ b/modules/org_policy_v2/README.md
@@ -98,7 +98,7 @@ To control module's behavior, change variables' values regarding the following:
 | policy\_root | Resource hierarchy node to apply the policy to: can be one of `organization`, `folder`, or `project`. | `string` | `"organization"` | no |
 | policy\_root\_id | The policy root id, either of organization\_id, folder\_id or project\_id | `string` | `null` | no |
 | policy\_type | The constraint type to work with (either 'boolean' or 'list') | `string` | `"list"` | no |
-| rules | List of rules per policy. Upto 10. | `list(any)` | n/a | yes |
+| rules | List of rules per policy. Up to 10. | <pre>list(object(<br>    {<br>      enforcement = bool<br>      allow       = list(string)<br>      deny        = list(string)<br>      conditions = list(object(<br>        {<br>          description = string<br>          expression  = string<br>          title       = string<br>          location    = string<br>        }<br>      ))<br>    }<br>  ))</pre> | n/a | yes |
 
 ## Outputs
 

--- a/modules/org_policy_v2/variables.tf
+++ b/modules/org_policy_v2/variables.tf
@@ -50,6 +50,20 @@ variable "policy_type" {
 }
 
 variable "rules" {
-  description = "List of rules per policy. Upto 10."
-  type        = list(any)
+  description = "List of rules per policy. Up to 10."
+  type = list(object(
+    {
+      enforcement = bool
+      allow       = list(string)
+      deny        = list(string)
+      conditions = list(object(
+        {
+          description = string
+          expression  = string
+          title       = string
+          location    = string
+        }
+      ))
+    }
+  ))
 }


### PR DESCRIPTION
Without this change Terraform would throw an error because it's unable to infer types.

The issue is similar to https://github.com/hashicorp/terraform/issues/30592#issuecomment-1183689596, and its fix is by adding a type constraint.