### PR TITLE
feat: support inheritance for list constraints on v2 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To control module's behavior, change variables' values regarding the following:
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 

--- a/examples/basic_org_policies/README.md
+++ b/examples/basic_org_policies/README.md
@@ -17,6 +17,6 @@ This example shows how to set a basic list of [organization policies](https://cl
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/boolean_org_exclude/README.md
+++ b/examples/boolean_org_exclude/README.md
@@ -25,6 +25,6 @@ module "folder-disable-serial-port-access-enforce-with-excludes" {
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/boolean_project_allow/README.md
+++ b/examples/boolean_project_allow/README.md
@@ -12,6 +12,6 @@ It disables enforcement of the `compute.disableSerialPortAccess` constraint on t
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/list_folder_deny/README.md
+++ b/examples/list_folder_deny/README.md
@@ -10,6 +10,6 @@ This example shows how a list constraint can be applied to disallow certain serv
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/examples/list_org_exclude/README.md
+++ b/examples/list_org_exclude/README.md
@@ -14,6 +14,6 @@ Specifically, it sets a trusted image policy so only images from a trusted image
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/bucket_policy_only/README.md
+++ b/modules/bucket_policy_only/README.md
@@ -16,6 +16,6 @@ This Terraform module allows to set a `Uniform Bucket-level Access` [Organizatio
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/domain_restricted_sharing/README.md
+++ b/modules/domain_restricted_sharing/README.md
@@ -17,6 +17,6 @@ This Terraform module allows to set a `Domain Restricted Sharing` [Organization 
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/org_policy_v2/README.md
+++ b/modules/org_policy_v2/README.md
@@ -95,6 +95,7 @@ To control module's behavior, change variables' values regarding the following:
 | constraint | The constraint to be applied | `string` | n/a | yes |
 | exclude\_folders | Set of folders to exclude from the policy | `set(string)` | `[]` | no |
 | exclude\_projects | Set of projects to exclude from the policy | `set(string)` | `[]` | no |
+| inherit\_from\_parent | Determines the inheritance behavior for this policy (only supported on list constraints) | `bool` | `"false"` | no |
 | policy\_root | Resource hierarchy node to apply the policy to: can be one of `organization`, `folder`, or `project`. | `string` | `"organization"` | no |
 | policy\_root\_id | The policy root id, either of organization\_id, folder\_id or project\_id | `string` | `null` | no |
 | policy\_type | The constraint type to work with (either 'boolean' or 'list') | `string` | `"list"` | no |

--- a/modules/org_policy_v2/list_constraints.tf
+++ b/modules/org_policy_v2/list_constraints.tf
@@ -24,6 +24,7 @@ resource "google_org_policy_policy" "organization_policy" {
   parent = "${local.policy_root}/${var.policy_root_id}"
 
   spec {
+    inherit_from_parent = var.inherit_from_parent
     dynamic "rules" {
       for_each = local.rules
       content {
@@ -60,6 +61,7 @@ resource "google_org_policy_policy" "folder_policy" {
   parent = "${local.policy_root}/${var.policy_root_id}"
 
   spec {
+    inherit_from_parent = var.inherit_from_parent
     dynamic "rules" {
       for_each = local.rules
       content {
@@ -96,6 +98,7 @@ resource "google_org_policy_policy" "project_policy" {
   parent = "${local.policy_root}/${var.policy_root_id}"
 
   spec {
+    inherit_from_parent = var.inherit_from_parent
     dynamic "rules" {
       for_each = local.rules
       content {

--- a/modules/org_policy_v2/variables.tf
+++ b/modules/org_policy_v2/variables.tf
@@ -49,6 +49,12 @@ variable "policy_type" {
   default     = "list"
 }
 
+variable "inherit_from_parent" {
+  description = "Determines the inheritance behavior for this policy (only supported on list constraints)"
+  type        = bool
+  default     = "false"
+}
+
 variable "rules" {
   description = "List of rules per policy. Up to 10."
   type = list(object(

--- a/modules/restrict_vm_external_ips/README.md
+++ b/modules/restrict_vm_external_ips/README.md
@@ -17,6 +17,6 @@ This Terraform module allows to set an `Allowed External IPs for VM instances` [
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/skip_default_network/README.md
+++ b/modules/skip_default_network/README.md
@@ -16,6 +16,6 @@ This Terraform module allows to set a `Skip Default Network Creation` [Organizat
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->


### PR DESCRIPTION
I might be missing something, but until now the v2 module did not support the `inheritFromParent` property.

https://cloud.google.com/resource-manager/docs/reference/orgpolicy/rest/v2/folders.policies#Policy.PolicySpec

The change in line 27 does not do much, but i left it in for consistency, so that the three blocks (org, folder, project) look the same.

https://github.com/kunzese/terraform-google-org-policy/blob/v2-inherit-from-parent/modules/org_policy_v2/list_constraints.tf#L27

The changes from `No output.` to `No outputs.` came from running `make generate_docs`.