### PR TITLE
docs: remove policy rule limit from documentation

### DIFF
--- a/modules/org_policy_v2/README.md
+++ b/modules/org_policy_v2/README.md
@@ -102,7 +102,6 @@ To control module's behavior, change variables' values regarding the following:
 - List policies (with `type: "list"`) can set `allow` and `deny` with a list of resources to allow or deny. For `enforcement` you can set it as follows:
   - set `enforcement` = false for `allow all`
   - set `enforcement` = true for `deny all`
-- Each policy can have [maximum of 10 rules](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/org_policy_policy#rules)
 
 ---
 


### PR DESCRIPTION
docs: Remove policy rule limit from documentation. The terraform v2 module [documentation](http://shortn/_PRvQj6SeyH) incorrectly calls out a 10 rule limit for org policies. This limitation was removed in 2023 (b/211006208).