### PR TITLE
feat: add support for organization principal set

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ credentials.json
 
 # tf lock file
 .terraform.lock.hcl
+.terraform.lock

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ crash.log
 
 # Files used for testing
 **/terraform.tfvars
+tmp/
 
 # Secrets
 credentials.json
@@ -46,4 +47,3 @@ credentials.json
 
 # tf lock file
 .terraform.lock.hcl
-

--- a/modules/domain_restricted_sharing/README.md
+++ b/modules/domain_restricted_sharing/README.md
@@ -7,13 +7,13 @@ This Terraform module allows to set a `Domain Restricted Sharing` [Organization 
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| domains\_to\_allow | The list of domains to allow users from | `list(string)` | `[]` | no |
+| domains\_to\_allow | The list of domains to allow users from. At least one valid value for 'domains\_to\_allow' or 'principal\_set\_org\_ids' must be provided | `list(string)` | `[]` | no |
 | exclude\_folders | Set of folders to exclude from the policy | `set(string)` | `[]` | no |
 | exclude\_projects | Set of projects to exclude from the policy | `set(string)` | `[]` | no |
 | folder\_id | The folder id for putting the policy | `string` | `null` | no |
 | organization\_id | The organization id for putting the policy | `string` | `null` | no |
 | policy\_for | Resource hierarchy node to apply the policy to: can be one of `organization`, `folder`, or `project`. | `string` | n/a | yes |
-| principal\_set\_org\_ids | The list of GCP Organization IDs to allow via Organization Principal Sets (e.g., ['123456789012']). See https://docs.cloud.google.com/organization-policy/restrict-domains#retrieving_organization_id | `list(string)` | `[]` | no |
+| principal\_set\_org\_ids | The list of GCP Organization IDs to allow via Organization Principal Sets (e.g., ['123456789012']). At least one valid value for 'principal\_set\_org\_ids' or 'domains\_to\_allow' must be provided. See https://docs.cloud.google.com/organization-policy/restrict-domains#retrieving_organization_id | `list(string)` | `[]` | no |
 | project\_id | The project id for putting the policy | `string` | `null` | no |
 
 ## Outputs

--- a/modules/domain_restricted_sharing/README.md
+++ b/modules/domain_restricted_sharing/README.md
@@ -1,18 +1,19 @@
 # Domain Restricted Sharing Module
 
-This Terraform module allows to set a `Domain Restricted Sharing` [Organization Policy](https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains) for a list of domains. The policy may be applied on organization, folder or project level.
+This Terraform module allows to set a `Domain Restricted Sharing` [Organization Policy](https://cloud.google.com/resource-manager/docs/organization-policy/restricting-domains) for a list of Google Workspace domains and/or Google Cloud Organization Principal Sets. The policy may be applied on organization, folder or project level.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| domains\_to\_allow | The list of domains to allow users from | `list(string)` | n/a | yes |
+| domains\_to\_allow | The list of domains to allow users from | `list(string)` | `[]` | no |
 | exclude\_folders | Set of folders to exclude from the policy | `set(string)` | `[]` | no |
 | exclude\_projects | Set of projects to exclude from the policy | `set(string)` | `[]` | no |
 | folder\_id | The folder id for putting the policy | `string` | `null` | no |
 | organization\_id | The organization id for putting the policy | `string` | `null` | no |
 | policy\_for | Resource hierarchy node to apply the policy to: can be one of `organization`, `folder`, or `project`. | `string` | n/a | yes |
+| principal\_set\_org\_ids | The list of GCP Organization IDs to allow via Organization Principal Sets (e.g., ['123456789012']). See https://docs.cloud.google.com/organization-policy/restrict-domains#retrieving_organization_id | `list(string)` | `[]` | no |
 | project\_id | The project id for putting the policy | `string` | `null` | no |
 
 ## Outputs

--- a/modules/domain_restricted_sharing/main.tf
+++ b/modules/domain_restricted_sharing/main.tf
@@ -18,6 +18,11 @@ data "google_organization" "orgs" {
   for_each = toset(var.domains_to_allow)
   domain   = each.value
 }
+locals {
+  customer_ids    = [for org in data.google_organization.orgs : org["directory_customer_id"]]
+  principal_sets  = [for id in var.principal_set_org_ids : "principalSet://iam.googleapis.com/organizations/${id}"]
+  allowed_members = concat(local.customer_ids, local.principal_sets)
+}
 
 module "allowed-policy-member-domains" {
   source            = "../../"
@@ -27,8 +32,17 @@ module "allowed-policy-member-domains" {
   project_id        = var.project_id
   constraint        = "constraints/iam.allowedPolicyMemberDomains"
   policy_type       = "list"
-  allow             = [for org in data.google_organization.orgs : org["directory_customer_id"]]
-  allow_list_length = length(var.domains_to_allow)
+  allow             = local.allowed_members
+  allow_list_length = length(var.domains_to_allow) + length(var.principal_set_org_ids)
   exclude_folders   = var.exclude_folders
   exclude_projects  = var.exclude_projects
+}
+
+resource "null_resource" "input_validation" {
+  lifecycle {
+    precondition {
+      condition     = length(var.domains_to_allow) > 0 || length(var.principal_set_org_ids) > 0
+      error_message = "Error: You must provide at least one domain in 'domains_to_allow' or at least one Org ID in 'principal_set_org_ids'."
+    }
+  }
 }

--- a/modules/domain_restricted_sharing/variables.tf
+++ b/modules/domain_restricted_sharing/variables.tf
@@ -38,13 +38,13 @@ variable "project_id" {
 }
 
 variable "domains_to_allow" {
-  description = "The list of domains to allow users from"
+  description = "The list of domains to allow users from. At least one valid value for 'domains_to_allow' or 'principal_set_org_ids' must be provided"
   type        = list(string)
   default     = []
 }
 
 variable "principal_set_org_ids" {
-  description = "The list of GCP Organization IDs to allow via Organization Principal Sets (e.g., ['123456789012']). See https://docs.cloud.google.com/organization-policy/restrict-domains#retrieving_organization_id"
+  description = "The list of GCP Organization IDs to allow via Organization Principal Sets (e.g., ['123456789012']). At least one valid value for 'principal_set_org_ids' or 'domains_to_allow' must be provided. See https://docs.cloud.google.com/organization-policy/restrict-domains#retrieving_organization_id"
   type        = list(string)
   default     = []
 }

--- a/modules/domain_restricted_sharing/variables.tf
+++ b/modules/domain_restricted_sharing/variables.tf
@@ -40,6 +40,13 @@ variable "project_id" {
 variable "domains_to_allow" {
   description = "The list of domains to allow users from"
   type        = list(string)
+  default     = []
+}
+
+variable "principal_set_org_ids" {
+  description = "The list of GCP Organization IDs to allow via Organization Principal Sets (e.g., ['123456789012']). See https://docs.cloud.google.com/organization-policy/restrict-domains#retrieving_organization_id"
+  type        = list(string)
+  default     = []
 }
 
 variable "exclude_folders" {

--- a/modules/domain_restricted_sharing/versions.tf
+++ b/modules/domain_restricted_sharing/versions.tf
@@ -22,6 +22,11 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 3.53, < 8"
     }
+
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 2.1.0"
+    }
   }
 
   provider_meta "google" {


### PR DESCRIPTION
This PR adds support for organization principal sets in the configuration of the Domain Restricted Sharing Org Policy. See https://docs.cloud.google.com/organization-policy/restrict-domains#retrieving_organization_id
